### PR TITLE
Another robust solution to fix SUSFS patch failure.

### DIFF
--- a/.github/workflows/fastbuild_6.1.128.yml
+++ b/.github/workflows/fastbuild_6.1.128.yml
@@ -134,6 +134,13 @@ jobs:
             sed -i '$i res=$(echo "$res" | sed '\''s/-dirty//g'\'')' "$f"
           done
 
+      - name: 应用128补丁
+        run: |
+          cd kernel_workspace/common
+          echo "正在添加6.1.128补丁..."
+          wget https://raw.githubusercontent.com/TWO666/oplus_kernel_builder/refs/heads/dev/other_patch/0001-opd2407_128.patch
+          git apply -p1 < 0001-opd2407_128.patch    
+
       - name: 配置ccache目录
         run: |
           echo "CCACHE_DIR=$HOME/.ccache_6.1.128" >> $GITHUB_ENV

--- a/other_patch/0001-opd2407_128.patch
+++ b/other_patch/0001-opd2407_128.patch
@@ -1,0 +1,71 @@
+diff --git a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
+index f163eaf30575..662612e1cbac 100755
+--- a/fs/proc/task_mmu.c
++++ b/fs/proc/task_mmu.c
+@@ -9,6 +9,7 @@
+ #include <linux/ptrace.h>
+ #include <linux/slab.h>
+ #include <linux/pagemap.h>
++#include <linux/pgsize_migration.h>
+ #include <linux/mempolicy.h>
+ #include <linux/rmap.h>
+ #include <linux/swap.h>
+@@ -357,7 +358,14 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
+ 
+ static int show_map(struct seq_file *m, void *v)
+ {
+-	show_map_vma(m, v);
++	struct vm_area_struct *pad_vma = get_pad_vma(v);
++	struct vm_area_struct *vma = get_data_vma(v);
++
++	if (vma_pages(vma))
++		show_map_vma(m, vma);
++
++	show_map_pad_vma(vma, pad_vma, m, show_map_vma, false);
++
+ 	return 0;
+ }
+ 
+@@ -916,7 +924,8 @@ static void __show_smap(struct seq_file *m, const struct mem_size_stats *mss,
+ 
+ static int show_smap(struct seq_file *m, void *v)
+ {
+-	struct vm_area_struct *vma = v;
++	struct vm_area_struct *pad_vma = get_pad_vma(v);
++	struct vm_area_struct *vma = get_data_vma(v);
+ 	struct mem_size_stats mss;
+ #if defined(CONFIG_CONT_PTE_HUGEPAGE) && defined(CONFIG_CONT_PTE_HUGEPAGE_DEBUG)
+ 	char buf[256];
+@@ -925,6 +934,9 @@ static int show_smap(struct seq_file *m, void *v)
+ 
+ 	memset(&mss, 0, sizeof(mss));
+ 
++	if (!vma_pages(vma))
++		goto show_pad;
++
+ 	smap_gather_stats(vma, &mss, 0);
+ 
+ 	show_map_vma(m, vma);
+@@ -1015,6 +1027,9 @@ static int show_smap(struct seq_file *m, void *v)
+ 		seq_printf(m, "ProtectionKey:  %8u\n", vma_pkey(vma));
+ 	show_smap_vma_flags(m, vma);
+ 
++show_pad:
++	show_map_pad_vma(vma, pad_vma, m, show_smap, true);
++
+ 	return 0;
+ }
+ 
+diff --git a/mm/Makefile b/mm/Makefile
+index 235610b41e83..5770c56a2f15 100644
+--- a/mm/Makefile
++++ b/mm/Makefile
+@@ -72,7 +72,7 @@ obj-y			:= filemap.o mempool.o oom_kill.o fadvise.o \
+ 			   mm_init.o percpu.o slab_common.o \
+ 			   compaction.o \
+ 			   interval_tree.o list_lru.o workingset.o \
+-			   debug.o gup.o mmap_lock.o $(mmu-y)
++			   debug.o gup.o mmap_lock.o pgsize_migration.o $(mmu-y)
+ 
+ # Give 'page_alloc' its own module-parameter namespace
+ page-alloc-y := page_alloc.o


### PR DESCRIPTION
Reference the implementation of `task_mmu.c` from the `oneplus/mt6897_v_15.0.2_nord_ce5` branch of   https://github.com/OnePlusOSS/android_kernel_oneplus_mt6897.

Tested on OPD2407. Both KernelSU Next and Sukisu Ultra are working properly.    