### PR TITLE
local: Fix docker build

### DIFF
--- a/local/builder_6.1.115.sh
+++ b/local/builder_6.1.115.sh
@@ -62,12 +62,22 @@ cd "$WORKDIR"
 
 # ===== 安装构建依赖 =====
 echo ">>> 安装构建依赖..."
-sudo apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
-sudo rm -rf /var/lib/man-db/auto-update
-sudo apt-get update
-sudo apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
-sudo rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
-sudo ./llvm.sh 20 all
+
+# Function to run a command with sudo if not already root
+SU() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+SU apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
+SU rm -rf /var/lib/man-db/auto-update
+SU apt-get update
+SU apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
+SU rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+SU ./llvm.sh 20 all
 
 # ===== 初始化仓库 =====
 echo ">>> 初始化仓库..."

--- a/local/builder_6.1.118.sh
+++ b/local/builder_6.1.118.sh
@@ -62,12 +62,22 @@ cd "$WORKDIR"
 
 # ===== 安装构建依赖 =====
 echo ">>> 安装构建依赖..."
-sudo apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
-sudo rm -rf /var/lib/man-db/auto-update
-sudo apt-get update
-sudo apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
-sudo rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
-sudo ./llvm.sh 20 all
+
+# Function to run a command with sudo if not already root
+SU() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+SU apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
+SU rm -rf /var/lib/man-db/auto-update
+SU apt-get update
+SU apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
+SU rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+SU ./llvm.sh 20 all
 
 # ===== 初始化仓库 =====
 echo ">>> 初始化仓库..."

--- a/local/builder_6.1.128.sh
+++ b/local/builder_6.1.128.sh
@@ -62,12 +62,22 @@ cd "$WORKDIR"
 
 # ===== 安装构建依赖 =====
 echo ">>> 安装构建依赖..."
-sudo apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
-sudo rm -rf /var/lib/man-db/auto-update
-sudo apt-get update
-sudo apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
-sudo rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
-sudo ./llvm.sh 20 all
+
+# Function to run a command with sudo if not already root
+SU() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+SU apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
+SU rm -rf /var/lib/man-db/auto-update
+SU apt-get update
+SU apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
+SU rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+SU ./llvm.sh 20 all
 
 # ===== 初始化仓库 =====
 echo ">>> 初始化仓库..."

--- a/local/builder_6.1.57.sh
+++ b/local/builder_6.1.57.sh
@@ -62,12 +62,22 @@ cd "$WORKDIR"
 
 # ===== 安装构建依赖 =====
 echo ">>> 安装构建依赖..."
-sudo apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
-sudo rm -rf /var/lib/man-db/auto-update
-sudo apt-get update
-sudo apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
-sudo rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
-sudo ./llvm.sh 20 all
+
+# Function to run a command with sudo if not already root
+su() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+SU apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
+SU rm -rf /var/lib/man-db/auto-update
+SU apt-get update
+SU apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
+SU rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+SU ./llvm.sh 20 all
 
 # ===== 初始化仓库 =====
 echo ">>> 初始化仓库..."

--- a/local/builder_6.1.75.sh
+++ b/local/builder_6.1.75.sh
@@ -62,12 +62,22 @@ cd "$WORKDIR"
 
 # ===== 安装构建依赖 =====
 echo ">>> 安装构建依赖..."
-sudo apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
-sudo rm -rf /var/lib/man-db/auto-update
-sudo apt-get update
-sudo apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
-sudo rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
-sudo ./llvm.sh 20 all
+
+# Function to run a command with sudo if not already root
+SU() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+SU apt-mark hold firefox && apt-mark hold libc-bin && apt-mark hold man-db
+SU rm -rf /var/lib/man-db/auto-update
+SU apt-get update
+SU apt-get install --no-install-recommends -y curl bison flex clang binutils dwarves git lld pahole zip perl make gcc python3 python-is-python3 bc libssl-dev libelf-dev cpio
+SU rm -rf ./llvm.sh && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+SU ./llvm.sh 20 all
 
 # ===== 初始化仓库 =====
 echo ">>> 初始化仓库..."


### PR DESCRIPTION
在多个本地构建脚本（builder_6.1.{57,75,115,118,128}.sh）中，原先所有 apt 相关及系统级操作均硬编码使用 `sudo`。
然而，在 Docker 容器环境中，构建进程通常以 root 用户身份运行（即无需 sudo），
强行使用 `sudo` 可能因容器未安装 sudo 或配置不当而导致构建失败。

为此，本提交引入了一个通用的 `SU()` 函数，用于智能判断当前用户是否为 root：
- 若已是 root（UID=0），则直接执行命令；
- 否则，通过 `sudo` 提权执行。

随后，将原脚本中所有显式的 `sudo` 调用替换为 `SU`，确保脚本既兼容传统用户环境，
也能在无 sudo 的 Docker 容器中顺利运行。

此修改显著提升了构建脚本在容器化 CI/CD 环境（如 Docker）中的健壮性与可移植性。